### PR TITLE
Add PHP 8.4 to GitHub Actions test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php-versions: [ '8.0', '8.1', '8.2', '8.3' ]
+        php-versions: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]
 
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php-versions: [ '8.0', '8.1', '8.2', '8.3' ]
+        php-versions: [ '8.0', '8.1', '8.2', '8.3', '8.4' ]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This update includes PHP 8.4 in the matrix of PHP versions used for testing in the GitHub Actions workflow. The addition ensures that the project's code is tested against the latest PHP version, enhancing compatibility and stability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the testing workflow to include PHP version 8.4, enhancing compatibility and support for the latest PHP features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->