### PR TITLE
PHP 8.5 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php-versions: [ '8.1', '8.2', '8.3', '8.4' ]
+        php-versions: [ '8.2', '8.3', '8.4', '8.5' ]
 
     steps:
       - uses: actions/checkout@v5
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php-versions: [ '8.1', '8.2', '8.3', '8.4' ]
+        php-versions: [ '8.2', '8.3', '8.4', '8.5' ]
 
     steps:
       - uses: actions/checkout@v5

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "phpdocumentor/shim": "^3.7",
-        "phpunit/phpunit": "^11.3|^12.2|13.0.x-dev",
+        "phpunit/phpunit": "^11.3|^12.2",
         "phpunit/php-code-coverage": "^11.0|^12.3",
         "phpstan/phpstan": "^2.0",
         "saggre/phpdocumentor-markdown": "^0.1.4 || ^1.0.0"

--- a/composer.json
+++ b/composer.json
@@ -17,14 +17,14 @@
         }
     ],
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "ext-pdo": "*",
         "ext-ctype": "*"
     },
     "require-dev": {
         "phpdocumentor/shim": "^3.7",
-        "phpunit/phpunit": "^10.5|^11.3|^12.2",
-        "phpunit/php-code-coverage": "^10.1|^11.0|^12.3",
+        "phpunit/phpunit": "^11.3|^12.2|13.0.x-dev",
+        "phpunit/php-code-coverage": "^11.0|^12.3",
         "phpstan/phpstan": "^2.0",
         "saggre/phpdocumentor-markdown": "^0.1.4 || ^1.0.0"
     },


### PR DESCRIPTION
This change will also drop PHP 8.1 support.

This will result in a 3.0.0 release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Minimum PHP requirement raised from 8.1 to 8.2.
  * Added support for PHP 8.5 and removed support for PHP 8.1.
  * CI workflows updated to test the new PHP version matrix.
  * Testing/dev dependencies upgraded to newer PHPUnit-family releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->